### PR TITLE
:green_heart: Fix mach-o build failure due to empty .a file

### DIFF
--- a/include/libhal-iot/iot.hpp
+++ b/include/libhal-iot/iot.hpp
@@ -16,5 +16,7 @@
 
 namespace hal::iot {
 struct iot_replace_me
-{};
+{
+  iot_replace_me();
+};
 }  // namespace hal::iot

--- a/src/iot.cpp
+++ b/src/iot.cpp
@@ -12,7 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "libhal-iot/iot.hpp"
+#include <libhal-iot/iot.hpp>
+
+namespace {
+int do_something_variable = 0;
+}
 
 namespace hal::iot {
+iot_replace_me::iot_replace_me()
+{
+  // Do nothing here, but give something to be contained in the .a archive file
+  do_something_variable++;
+}
 }  // namespace hal::iot

--- a/test_package/main.cpp
+++ b/test_package/main.cpp
@@ -16,5 +16,5 @@
 
 int main()
 {
-  hal::iot::iot_replace_me bar;
+  hal::iot::iot_replace_me foo;
 }


### PR DESCRIPTION
Mac seems to not like archive files that are completely empty, so we need to put something in there for the `test_package` to work.