### PR TITLE
:package: Set python_requires mode to major_mode

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -38,3 +38,6 @@ class libhal_iot_conan(ConanFile):
     def package_info(self):
         self.cpp_info.libs = ["libhal-iot"]
         self.cpp_info.set_property("cmake_target_name", "libhal::iot")
+
+    def package_id(self):
+        self.info.python_requires.major_mode()


### PR DESCRIPTION
By setting the mode for `python_requires` to `major_mode` only the major_mode

will represent a breaking change between new versions of `libhal-bootstrap`.